### PR TITLE
Afbase/tcp connect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ failure = "0.1.5"
 name = "runqlat"
 path = "src/runqlat/main.rs"
 
+[[bin]]
+name = "tcpconnect"
+path = "src/tcpconnect/main.rs"
+
 [features]
 static = ["bcc/static"]
 bcc_specific = []

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -54,7 +54,7 @@ if [ -n "${BCC_VERSION}" ]; then
     cd ../..
 fi
 
-## Build and test
+
 ## Build and test
 if [ -n "${FEATURES}" ]; then
     cargo build --features "${FEATURES}"
@@ -62,10 +62,14 @@ if [ -n "${FEATURES}" ]; then
     cargo build --release --features "${FEATURES}"
     cargo test --release --features "${FEATURES}"
     sudo target/release/runqlat --interval 1 --windows 5
+    timeout --signal=INT --preserve-status 1.0m bash -c 'while true; do curl google.com; sleep 5; done &>/dev/null &'
+    sudo timeout --signal=INT --preserve-status 1.0m ./target/release/tcpconnect
 else
     cargo build
     cargo test
     cargo build --release
     cargo test --release
     sudo target/release/runqlat --interval 1 --windows 5
+    timeout --signal=INT --preserve-status 1.0m bash -c 'while true; do curl google.com; sleep 5; done &>/dev/null &'
+    sudo timeout --signal=INT --preserve-status 1.0m ./target/release/tcpconnect
 fi

--- a/src/tcpconnect/bpf.c
+++ b/src/tcpconnect/bpf.c
@@ -1,0 +1,125 @@
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <bcc/proto.h>
+
+BPF_HASH(currsock, u32, struct sock *);
+
+// separate data structs for ipv4 and ipv6
+struct ipv4_data_t {
+    u64 ts_us;
+    u32 pid;
+    u32 uid;
+    u32 saddr;
+    u32 daddr;
+    u64 ip;
+    u16 dport;
+    char task[TASK_COMM_LEN];
+};
+BPF_PERF_OUTPUT(ipv4_events);
+
+struct ipv6_data_t {
+    u64 ts_us;
+    u32 pid;
+    u32 uid;
+    unsigned __int128 saddr;
+    unsigned __int128 daddr;
+    u64 ip;
+    u16 dport;
+    char task[TASK_COMM_LEN];
+};
+BPF_PERF_OUTPUT(ipv6_events);
+
+// separate flow keys per address family
+struct ipv4_flow_key_t {
+    u32 saddr;
+    u32 daddr;
+    u16 dport;
+};
+BPF_HASH(ipv4_count, struct ipv4_flow_key_t);
+
+struct ipv6_flow_key_t {
+    unsigned __int128 saddr;
+    unsigned __int128 daddr;
+    u16 dport;
+};
+BPF_HASH(ipv6_count, struct ipv6_flow_key_t);
+
+int trace_connect_entry(struct pt_regs *ctx, struct sock *sk)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = pid_tgid;
+    FILTER_PID
+
+    u32 uid = bpf_get_current_uid_gid();
+    FILTER_UID
+
+    // stash the sock ptr for lookup on return
+    currsock.update(&tid, &sk);
+
+    return 0;
+};
+
+static int trace_connect_return(struct pt_regs *ctx, short ipver)
+{
+    int ret = PT_REGS_RC(ctx);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = pid_tgid;
+    struct sock **skpp;
+    skpp = currsock.lookup(&tid);
+    if (skpp == 0) {
+        return 0;   // missed entry
+    }
+    if (ret != 0) {
+        // failed to send SYNC packet, may not have populated
+        // socket __sk_common.{skc_rcv_saddr, ...}
+        currsock.delete(&tid);
+        return 0;
+    }
+    // pull in details
+    struct sock *skp = *skpp;
+    u16 dport = skp->__sk_common.skc_dport;
+
+    FILTER_PORT
+
+    // TRACE template code for ipv4 and ipv6
+    if (ipver == 4) {
+        u64 address_pair = skp->__sk_common.skc_addrpair; 
+        struct ipv4_data_t data4 = {.pid = pid, .ip = ipver};
+        bpf_get_current_comm(&data4.task, sizeof(data4.task));
+        data4.uid = bpf_get_current_uid_gid();
+        data4.ts_us = bpf_ktime_get_ns() / 1000;
+        data4.dport = ntohs(dport);
+        data4.daddr = address_pair;
+        data4.saddr = address_pair >> 32;
+        ipv4_events.perf_submit(ctx, &data4, sizeof(data4));
+    }
+    else /* 6 */
+    {
+        struct ipv6_data_t data6 = {.pid = pid, .ip = ipver};
+        data6.uid = bpf_get_current_uid_gid();
+        data6.ts_us = bpf_ktime_get_ns() / 1000;
+        bpf_probe_read( &data6.saddr, 
+                        sizeof(data6.saddr),
+                        skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+        bpf_probe_read( &data6.daddr, 
+                        sizeof(data6.daddr),
+                        skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+        data6.dport = ntohs(dport);
+        bpf_get_current_comm(&data6.task, sizeof(data6.task));
+        ipv6_events.perf_submit(ctx, &data6, sizeof(data6));
+    }
+    currsock.delete(&tid);
+    return 0;
+}
+
+int trace_connect_v4_return(struct pt_regs *ctx)
+{
+    return trace_connect_return(ctx, 4);
+}
+
+int trace_connect_v6_return(struct pt_regs *ctx)
+{
+    return trace_connect_return(ctx, 6);
+}

--- a/src/tcpconnect/main.rs
+++ b/src/tcpconnect/main.rs
@@ -1,0 +1,234 @@
+use bcc::core::BPF;
+use clap::{App, Arg};
+use core::sync::atomic::{AtomicBool, Ordering};
+use failure::Error;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::{ptr, str};
+
+/*
+ * Define the struct the BPF code writes in Rust
+ * This must match the struct in `opensnoop.c` exactly.
+ * The important thing to understand about the code in `opensnoop.c` is that it creates structs of
+ * type `data_t` and pushes them into a buffer where our Rust code can read them.
+ */
+#[repr(C)]
+struct ipv4_data_t {
+    ts_us: u64,
+    pid: u32,
+    uid: u32,
+    saddr: u32,
+    daddr: u32,
+    ip: u64,
+    dport: u16,
+    task: [u8; 16], // TASK_COMM_LEN
+}
+
+#[repr(C)]
+struct ipv6_data_t {
+    ts_us: u64,
+    pid: u32,
+    uid: u32,
+    saddr: u128,
+    daddr: u128,
+    ip: u64,
+    dport: u16,
+    task: [u8; 16], // TASK_COMM_LEN
+}
+
+trait IpDataParse<Output> {
+    fn parse_data_t_struct(x: &[u8]) -> Output;
+}
+
+impl IpDataParse<ipv4_data_t> for ipv4_data_t {
+    fn parse_data_t_struct(x: &[u8]) -> ipv4_data_t {
+        unsafe { ptr::read(x.as_ptr() as *const ipv4_data_t) }
+    }
+}
+
+impl IpDataParse<ipv6_data_t> for ipv6_data_t {
+    fn parse_data_t_struct(x: &[u8]) -> ipv6_data_t {
+        unsafe { ptr::read(x.as_ptr() as *const ipv6_data_t) }
+    }
+}
+
+fn perf_ipv4_data_t_callback() -> Box<dyn FnMut(&[u8]) + Send> {
+    Box::new(|x| {
+        // This callback
+        let data: ipv4_data_t = ipv4_data_t::parse_data_t_struct(x);
+        if let Ok(task) = str::from_utf8(&data.task) {
+            println!(
+                "{: <6} {: <6} {: <16} {: <16} {: <16} {: <16} {: <4}", // "UID", "PID", "COMM", "IP", "SADDR", "DADDR", "DPORT"
+                data.uid,
+                data.pid,
+                task.trim_end_matches('\0'),
+                data.ip,
+                Ipv4Addr::from(htonl(data.saddr)).to_string(),
+                Ipv4Addr::from(htonl(data.daddr)).to_string(),
+                data.dport
+            );
+        }
+    })
+}
+
+fn perf_ipv6_data_t_callback() -> Box<dyn FnMut(&[u8]) + Send> {
+    Box::new(|x| {
+        // This callback
+        let data: ipv6_data_t = ipv6_data_t::parse_data_t_struct(x);
+        // .swap_bytes() always swap bytes, .to_be_bytes() swap if host is le, .to_le_bytes() swaps if host is be
+        let saddr: u128 = u128::from_le_bytes(data.saddr.to_be_bytes());
+        let daddr: u128 = u128::from_le_bytes(data.daddr.to_be_bytes());
+        if let Ok(task) = str::from_utf8(&data.task) {
+            println!(
+                "{: <6} {: <6} {: <16} {: <16} {: <16} {: <16} {: <4}", // "UID", "PID", "COMM", "IP", "SADDR", "DADDR", "DPORT"
+                data.uid,
+                data.pid,
+                task.trim_end_matches('\0'),
+                data.ip,
+                Ipv6Addr::from(saddr).to_string(),
+                Ipv6Addr::from(daddr).to_string(),
+                data.dport
+            );
+        }
+    })
+}
+
+fn ntohs(u: u16) -> u16 {
+    u16::from_be(u)
+}
+fn htonl(u: u32) -> u32 {
+    u.to_be()
+}
+
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+    let mut bpf_text: String = include_str!("bpf.c").to_string();
+    let matches = App::new("tcpconnect")
+        .about("Trace TCP connects")
+        .long_about(
+            "examples:
+./tcpconnect           # trace all TCP connect()s
+./tcpconnect -p 181    # only trace PID 181
+./tcpconnect -P 80     # only trace port 80
+./tcpconnect -P 22 8080  # only trace port 22 and 8080
+./tcpconnect -u 1000   # only trace UID 1000",
+        )
+        .arg(
+            Arg::with_name("uid")
+                .short("u")
+                .long("uid")
+                .help("trace this UID only, e.g. -u 2322")
+                .value_name("UID")
+                .number_of_values(1)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("pid")
+                .short("p")
+                .long("pid")
+                .help("trace this PID only, e.g. -p 343")
+                .value_name("PID")
+                .number_of_values(1)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("port")
+                .short("P")
+                .long("port")
+                .help("destination ports to trace, e.g. -P 22 80 443")
+                .value_name("PORT")
+                .min_values(1)
+                .required(false)
+                .takes_value(true),
+        )
+        .get_matches();
+    // handle pids
+    if let Some(p) = matches.value_of("pid") {
+        // trace pid
+        let pid = p
+            .parse::<u32>()
+            .expect("pid should be a non-negative integer");
+        bpf_text = {
+            let pid_format = format!("if (pid != {}) {{ return 0; }}", pid);
+            bpf_text.replace("FILTER_PID", pid_format.as_str())
+        };
+    }
+    // handle ports
+    if let Some(port_listings) = matches.values_of("port") {
+        let mut ports_conditions: Vec<String> = Vec::new();
+        for port in port_listings {
+            let port_u16 = port.parse::<u16>().expect("port number between 1-65535");
+            let port_ntohs = ntohs(port_u16);
+            let port_condition = format!("dport != {}", port_ntohs);
+            ports_conditions.push(port_condition);
+        }
+        bpf_text = bpf_text.replace(
+            "FILTER_PORT",
+            format!(
+                "if ({}) {{ currsock.delete(&pid); return 0; }}",
+                ports_conditions.join(" && ")
+            )
+            .as_str(),
+        );
+    }
+    // handle uid
+    if let Some(u) = matches.value_of("uid") {
+        // trace uuid
+        let uuid = u
+            .parse::<u32>()
+            .expect("uuid value should be an non-negative integer integer");
+        bpf_text = {
+            let uuid_set = format!("if (uid != {}) {{ return 0; }}", uuid);
+            bpf_text.replace("FILTER_UID", uuid_set.as_str())
+        };
+    }
+    // replace remaining unset template flags, if any
+    bpf_text = bpf_text.replace("FILTER_PID", "");
+    bpf_text = bpf_text.replace("FILTER_PORT", "");
+    bpf_text = bpf_text.replace("FILTER_UID", "");
+
+    // compile the above BPF code!
+    let mut module = BPF::new(bpf_text.as_str())?;
+    // load + attach tracepoints!
+    let trace_connect_v4_entry = module.load_kprobe("trace_connect_entry")?;
+    let trace_connect_v6_entry = module.load_kprobe("trace_connect_entry")?;
+    let trace_connect_v4_return = module.load_kprobe("trace_connect_v4_return")?;
+    let trace_connect_v6_return = module.load_kprobe("trace_connect_v6_return")?;
+    module.attach_kprobe("tcp_v4_connect", trace_connect_v4_entry)?;
+    module.attach_kprobe("tcp_v6_connect", trace_connect_v6_entry)?;
+    module.attach_kretprobe("tcp_v4_connect", trace_connect_v4_return)?;
+    module.attach_kretprobe("tcp_v6_connect", trace_connect_v6_return)?;
+
+    println!("Tracing connect ... Hit Ctrl-C to end");
+    let ipv4_table = module.table("ipv4_events");
+    let ipv6_table = module.table("ipv6_events");
+    let _ipv4_perf_map = module.init_perf_map(ipv4_table, perf_ipv4_data_t_callback)?;
+    let _ipv6_perf_map = module.init_perf_map(ipv6_table, perf_ipv6_data_t_callback)?;
+    // print a header
+    println!(
+        "{: <6} {: <6} {: <16} {: <16} {: <16} {: <16} {: <4}",
+        "UID", "PID", "COMM", "IP", "SADDR", "DADDR", "DPORT"
+    );
+
+    while runnable.load(Ordering::SeqCst) {
+        module.perf_map_poll(200);
+    }
+    Ok(())
+}
+
+fn main() {
+    let runnable = Arc::new(AtomicBool::new(true));
+    let r = runnable.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Failed to set handler for SIGINT / SIGTERM");
+
+    match do_main(runnable) {
+        Err(x) => {
+            eprintln!("Error: {}", x);
+            eprintln!("{}", x.backtrace());
+            std::process::exit(1);
+        }
+        _ => {}
+    }
+}


### PR DESCRIPTION
briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)
 - Adding a very simple tcpconnect example
* what changes does this pull request make?
 - src/tcpconnect folder contents + new bin target in Cargo.toml
* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)
```
warning: trait objects without an explicit `dyn` are deprecated
  --> src/tcpconnect/main.rs:59:39
   |
59 | fn perf_ipv4_data_t_callback() -> Box<FnMut(&[u8]) + Send> {
   |                                       ^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn FnMut(&[u8]) + Send`
   |
   = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
  --> src/tcpconnect/main.rs:78:39
   |
78 | fn perf_ipv6_data_t_callback() -> Box<FnMut(&[u8]) + Send> {
   |                                       ^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn FnMut(&[u8]) + Send`

```
I get a warning about my callback functions suggesting I use `dyn`.  I'm still trying to understand this issue.

I tested on ubuntu 18.04 for both ipv6 and ipv4 addresses.